### PR TITLE
fix: multiline drawingOptions

### DIFF
--- a/NSLabel.m
+++ b/NSLabel.m
@@ -177,7 +177,7 @@
 - (NSStringDrawingOptions)drawingOptions {
 	NSStringDrawingOptions options = NSStringDrawingUsesFontLeading;
 
-	if (self.numberOfLines == 0) {
+	if (self.numberOfLines != 1) {
 		options |= NSStringDrawingUsesLineFragmentOrigin;
 	}
 


### PR DESCRIPTION
Apple docs [here](https://developer.apple.com/documentation/foundation/nsstring/1524729-boundingrectwithsize?language=objc) say this:
> To correctly draw and size multi-line text, pass [NSStringDrawingUsesLineFragmentOrigin](https://developer.apple.com/documentation/uikit/nsstringdrawingoptions/nsstringdrawinguseslinefragmentorigin?language=objc) in the options parameter.

Yet `NSLabel` was only using that option when `numberOfLines == 0`.