### PR TITLE
import AppKit instead of Cocoa (and update links in docs)

### DIFF
--- a/NSLabel.h
+++ b/NSLabel.h
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#import <Cocoa/Cocoa.h>
+#import <AppKit/AppKit.h>
 
 IB_DESIGNABLE
 @interface NSLabel : NSView

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ObjC 2.0 and Automatic Reference Counting (ARC) are mandatory.
 This project has only been tested with Xcode 6. It's unknown if this works with older versions.
 
 #### Dependencies
-There are no dependencies other than the Cocoa framework.
+There are no dependencies other than the AppKit framework.
 
 #### Usage
 Simply include NSLabel.h/.m in your project and use it like the [UILabel Class](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UILabel_Class/).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # NSLabel
 
-This project aims at replicating the most important features of the famous [UILabel](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UILabel_Class/) on Mac OS X.
+This project aims at replicating the most important features of the famous [UILabel][1] on Mac OS X.
 
-It's biggest advantage compared to [NSTextField](https://developer.apple.com/library/prerelease/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSTextField_Class/) is a more lightweight memory and CPU footprint and a near pixel perfect rendering. I.e. the [intrinsicContentSize](https://developer.apple.com/library/mac//documentation/Cocoa/Reference/ApplicationKit/Classes/NSView_Class/index.html#//apple_ref/occ/instp/NSView/intrinsicContentSize) matches the actual frame of the text and the [baselineOffsetFromBottom](https://developer.apple.com/library/mac//documentation/Cocoa/Reference/ApplicationKit/Classes/NSView_Class/index.html#//apple_ref/occ/instp/NSView/baselineOffsetFromBottom) is correctly computed and can be used with Auto Layout.
+It's biggest advantage compared to [NSTextField][2] is a more lightweight memory and CPU footprint and a near pixel perfect rendering. I.e. the [intrinsicContentSize][3] matches the actual frame of the text and the [baselineOffsetFromBottom][4] is correctly computed and can be used with Auto Layout.
+
+[1]: https://developer.apple.com/documentation/uikit/uilabel?language=objc
+[2]: https://developer.apple.com/documentation/appkit/nstextfield?language=objc
+[3]: https://developer.apple.com/documentation/appkit/nsview/1526996-intrinsiccontentsize?language=objc
+[4]: https://developer.apple.com/documentation/appkit/nsview/1526949-baselineoffsetfrombottom?language=objc
 
 #### Requirements
 ObjC 2.0 and Automatic Reference Counting (ARC) are mandatory.
@@ -13,7 +18,7 @@ This project has only been tested with Xcode 6. It's unknown if this works with 
 There are no dependencies other than the AppKit framework.
 
 #### Usage
-Simply include NSLabel.h/.m in your project and use it like the [UILabel Class](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UILabel_Class/).
+Simply include NSLabel.h/.m in your project and use it like the [UILabel][1] class.
 **BUT** remember that not all features are supported.
 See the Header file for more information about which properties currently are.
 


### PR DESCRIPTION
This library has no need for CoreData, and AppKit imports Foundation for us! 🎉 